### PR TITLE
Feat/update yeons qa

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className="h-screen w-screen">
+    <html lang="en" suppressHydrationWarning className="dark h-screen w-screen">
       <link rel="icon" type="image/x-icon" href="/favicon.ico" />
       <body
         id="root-container"

--- a/src/feature/charts/ui/GassCalnerder.tsx
+++ b/src/feature/charts/ui/GassCalnerder.tsx
@@ -7,15 +7,14 @@ import useGrassChart from '../model/grassChartHook';
 
 const getColorByCount = (count: number) => {
   if (count === 0)
-    return 'bg-grass border border-[#D3D3D3]/70 dark:border-white';
-  if (count <= 2) return 'bg-grass-100';
-  if (count <= 4) return 'bg-grass-200';
-  if (count <= 7) return 'bg-grass-300';
-  if (count <= 10) return 'bg-grass-400';
+    return 'bg-transparent border border-gray-400/70 dark:border-white/50';
+  if (count <= 2) return 'bg-yellow-100';
+  if (count <= 4) return 'bg-yellow-300';
+  if (count <= 7) return 'bg-yellow-400';
+  if (count <= 10) return 'bg-yellow-500';
 
-  return 'bg-grass-500';
+  return 'bg-yellow-600';
 };
-
 const GrassChart = () => {
   const { stats } = useGrassChart();
 
@@ -83,19 +82,22 @@ const GrassChart = () => {
       </div>
 
       {/* 달력 날짜 셀 */}
-      <div className="aspect-square grid h-auto w-full grid-cols-7 gap-0 text-center text-sm">
+      <div className="aspect-square grid h-auto w-full grid-cols-7 gap-2 text-center text-sm">
         {daysArray.map((cell, idx) =>
           cell ? (
             <div
               key={idx}
-              className={`flex h-[50px] items-center justify-center rounded-full ${cell.count === 0 ? 'text-black dark:text-white' : 'text-black'} transition-colors ${getColorByCount(
+              className={`flex h-[45px] w-[45px] items-center justify-center rounded-full transition-colors ${getColorByCount(
                 cell.count
-              )}`}
+              )} ${cell.count > 0 ? 'text-black' : 'text-gray-500 dark:text-gray-300'}`}
             >
-              {cell.count > 0 ? cell.count : '0'}
+              {cell.count > 0 ? cell.count : ''}
             </div>
           ) : (
-            <div key={idx} className="aspect-square" />
+            <div
+              key={idx}
+              className="flex h-[45px] w-[45px] items-center justify-center rounded-full border border-dashed border-gray-400/50 dark:border-white/30"
+            />
           )
         )}
       </div>

--- a/src/feature/mypage/ui/Item.tsx
+++ b/src/feature/mypage/ui/Item.tsx
@@ -34,49 +34,6 @@ export const QuestionItem: React.FC<ItemProps> = ({
 
   return (
     <>
-      {/* <div className="rounded-lg bg-[#5500FF] opacity-[40%]">
-        <div className="flex gap-5">
-          <span className="text-[1.5vh] font-semibold">
-            {truncateText(questionTitle, 40)}
-          </span>
-          <p className="text-[1.5vh] text-gray-500">
-            난이도 : {Math.floor(Math.abs(score))}
-          </p>
-        </div>
-
-        <button
-          onClick={() => setIsPopupOpen(true)}
-          className="flex items-center justify-center gap-5 rounded-xl bg-[#FEBA73] p-2 text-[1.5vh] text-white"
-        >
-          자세히 보기
-          <FaArrowRightLong />
-        </button>
-      </div>
-      <div className="flex items-center justify-between rounded-lg bg-white p-3 shadow-lg md:hidden">
-        <div className="flex items-center gap-5">
-          <span className={`ml-2 text-sm font-semibold ${textColorClass}`}>
-            {(index + 1).toString().padStart(2, '0')}
-          </span>
-          {isCorrectAnswer ? (
-            <CircleCheck
-              size={20}
-              className="text-green-600"
-              strokeWidth={2.5}
-            />
-          ) : (
-            <CircleX size={20} className="text-red-600" strokeWidth={2.5} />
-          )}
-          <div className="flex items-center">
-            <span className="text-[1.5vh] font-semibold">
-              <h2>문제 제목</h2> {truncateText(questionTitle, 30)}
-            </span>
-          </div>
-        </div>
-
-        <div className="h-7 w-7" onClick={() => setIsPopupOpen(true)}>
-          <SvgIcon inheritViewBox component={Arrow} />
-        </div>
-      </div> */}
       <div className="flex h-[100px] w-full flex-col rounded-sm bg-[#451E81] pb-8p pl-16p pr-16p pt-8p">
         <div className="flex gap-2">
           <span

--- a/src/page/level_result_solution/ui/index.tsx
+++ b/src/page/level_result_solution/ui/index.tsx
@@ -12,6 +12,10 @@ import CircleCancel from '@public/assets/icons/leveltest/Subtract.svg';
 import ButtonPixel from '@/shared/button/buttonPixel';
 import { useRouter } from 'next/navigation';
 import { RouteTo } from '@/shared/routes/model/getRoutePath';
+import useSolvingProblem from '@/page/solve/model/solvingProblemHook';
+import Toaster from '@/shared/toast/ui/toaster';
+import { ProblemCategoryTitle } from '@/shared/problem/model/problemInfo.types';
+import { toastStore, ToastType } from '@/shared/state/toast/toastStore';
 
 const TestResultSolutionPage = ({
   type,
@@ -32,6 +36,10 @@ const TestResultSolutionPage = ({
     (!problemId && !userAnswer && !problemInfo)
   )
     return;
+
+  const { bookMarkToggle } = useSolvingProblem(
+    problemInfo?.category.split('_')[0] as ProblemCategoryTitle
+  );
 
   const [problemDetailInfo, setProblemDetailInfo] = useState<
     ProblemDetailInfoRes | undefined | null
@@ -71,6 +79,7 @@ const TestResultSolutionPage = ({
 
   return (
     <div className="flex h-full w-full flex-col overflow-y-auto px-4 py-5 scrollbar-hide">
+      <Toaster />
       <span className="text-title-page">Result Summary</span>
       <div className="mt-2 flex flex-col">
         <span className="mt-2 text-title-section text-point-logo">
@@ -136,8 +145,21 @@ const TestResultSolutionPage = ({
           <>
             <ButtonPixel
               status="default"
-              onClick={() => {
-                // 스크랩 api 호출
+              onClick={async () => {
+                if (problemId) {
+                  const success = await bookMarkToggle(problemId);
+                  if (success) {
+                    toastStore.show({
+                      status: ToastType.success,
+                      title: '북마크가 추가되었습니다',
+                    });
+                  } else {
+                    toastStore.show({
+                      status: ToastType.info,
+                      title: '북마크 실패',
+                    });
+                  }
+                }
               }}
             >
               Save this result
@@ -156,12 +178,26 @@ const TestResultSolutionPage = ({
           <>
             <ButtonPixel
               status="default"
-              onClick={() => {
-                // 스크랩 api 호출
+              onClick={async () => {
+                if (problemId) {
+                  const success = await bookMarkToggle(problemId);
+                  if (success) {
+                    toastStore.show({
+                      status: ToastType.success,
+                      title: '북마크가 추가되었습니다',
+                    });
+                  } else {
+                    toastStore.show({
+                      status: ToastType.info,
+                      title: '북마크 실패',
+                    });
+                  }
+                }
               }}
             >
               Save this result
             </ButtonPixel>
+
             <ButtonPixel
               status="default"
               onClick={() => {
@@ -193,8 +229,21 @@ const TestResultSolutionPage = ({
           <>
             <ButtonPixel
               status="default"
-              onClick={() => {
-                // 스크랩 api 호출
+              onClick={async () => {
+                if (problemId) {
+                  const success = await bookMarkToggle(problemId);
+                  if (success) {
+                    toastStore.show({
+                      status: ToastType.success,
+                      title: '북마크가 추가되었습니다',
+                    });
+                  } else {
+                    toastStore.show({
+                      status: ToastType.info,
+                      title: '북마크 실패',
+                    });
+                  }
+                }
               }}
             >
               Save this result

--- a/src/page/login/ui/index.tsx
+++ b/src/page/login/ui/index.tsx
@@ -28,7 +28,7 @@ const LoginPage = () => {
   } = useLoginPage();
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center px-4">
+    <div className="flex h-full w-full flex-col items-center justify-center px-4 text-black dark:text-white">
       <div className="flex w-full flex-col justify-center">
         <SvgIcon
           component={HomeLogo}

--- a/src/page/mypage/ui/Profile.tsx
+++ b/src/page/mypage/ui/Profile.tsx
@@ -75,19 +75,21 @@ const Profile = () => {
       {isModalOpen && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-70">
           <div className="w-[90%] rounded bg-white p-5 shadow-lg md:w-[30rem]">
-            <h2 className="ml-1 text-base font-semibold">변경할 닉네임</h2>
+            <h2 className="ml-1 text-base font-semibold text-black">
+              변경할 닉네임
+            </h2>
             <input
               type="text"
               value={newNickname}
               onChange={(e) => setNewNickname(e.target.value)}
-              className="mt-2 w-full rounded border p-2 font-spoqa"
+              className="mt-2 w-full rounded border p-2 font-spoqa text-black"
               placeholder="새 닉네임을 입력하세요"
             />
             <div className="mt-3 flex justify-end gap-2">
               <Button
                 size="xxs"
                 rounded={true}
-                className="rounded-full bg-gray-300 pl-[0.05rem] pt-0.5 font-mono text-[0.8rem] font-medium"
+                className="rounded-full bg-gray-400 pl-[0.05rem] pt-0.5 font-pixel text-[0.8rem] font-medium"
                 onClick={() => setIsModalOpen(false)}
               >
                 취소

--- a/src/page/mypage/ui/Profile.tsx
+++ b/src/page/mypage/ui/Profile.tsx
@@ -24,7 +24,7 @@ const Profile = () => {
     <div className="flex gap-16p font-pixel">
       {/* 프로필 이미지 */}
       <label htmlFor="profile-upload" className="">
-        <div className="flex h-[12vh] w-[12vh]">
+        <div className="z-[1000] flex h-[12vh] w-[12vh]">
           <div className="">
             <SvgIcon
               inheritViewBox

--- a/src/page/mypage/ui/categoryProblemHistory.tsx
+++ b/src/page/mypage/ui/categoryProblemHistory.tsx
@@ -38,31 +38,35 @@ const CategoryProblemHistoryPage = () => {
         Solution Archive
       </span>
       <div className="mt-[20px] flex w-full flex-col">
-        <div className="flex flex-col justify-between">
-          <div className="flex flex-col gap-3 pb-[10px]">
+        <div className="flex h-[85vh] flex-col justify-between gap-3 pb-[10px]">
+          <div className="flex flex-col gap-3">
             {paginatedHistory.length > 0 ? (
-              paginatedHistory.map((history, index) => (
-                <QuestionItem
-                  key={history.historyId}
-                  index={startIndex + index}
-                  isCorrectAnswer={history.isCorrect}
-                  userAnswer={history.userAnswer}
-                  userId={history.userId}
-                  historyId={history.historyId}
-                  questionId={history.questionId}
-                  questionTitle={history.questionTitle}
-                  score={history.score}
-                  textColorClass={textColorClass}
-                  category={category}
-                  createdDt={history.createdDt}
-                />
-              ))
+              paginatedHistory.map((history, index) => {
+                console.log(history); // 로그 출력
+                return (
+                  <QuestionItem
+                    key={history.historyId}
+                    index={startIndex + index}
+                    isCorrectAnswer={history.isCorrect}
+                    userAnswer={history.userAnswer}
+                    userId={history.userId}
+                    historyId={history.historyId}
+                    questionId={history.questionId}
+                    questionTitle={history.questionTitle}
+                    score={history.score}
+                    textColorClass={textColorClass}
+                    category={category}
+                    createdDt={history.createdDt}
+                  />
+                );
+              })
             ) : (
               <p>해당 카테고리 문제 데이터가 없습니다.</p>
             )}
           </div>
+
           {filteredHistory.length > 0 && (
-            <div className="mb-[80px] mt-4 flex justify-center">
+            <div className="mb-[10px] mt-4 flex justify-center">
               <ProblemPagination
                 page={page}
                 setPage={setPage}

--- a/src/page/mypage/ui/list/CheckList.tsx
+++ b/src/page/mypage/ui/list/CheckList.tsx
@@ -22,35 +22,6 @@ const CheckList: React.FC<CheckListProps> = ({ questionHistory }) => {
     <>
       <div className="flex-col items-center overflow-auto pb-[50px] pt-[20px]">
         <div className="w-[100%] overflow-auto scrollbar-hide">
-          {/* <div className="flex">
-            {TempCategories.map((category, index) => {
-              const bgColorClass = categoryBgColors[category.title] ?? '';
-
-              return (
-                <div
-                  key={index}
-                  onClick={() => setSelectedCategory(category.title)}
-                  className={`hidden h-[3rem] w-[150px] cursor-pointer flex-col items-center justify-center rounded-tr-2xl px-4 pt-2.5 md:flex md:p-4 ${bgColorClass}`}
-                >
-                  <div className="flex h-[3rem] justify-center">
-                    <span
-                      className={`flex items-center text-title-section font-bold ${
-                        selectedCategory === category.title
-                          ? 'text-black'
-                          : 'text-gray-500'
-                      }`}
-                      style={{
-                        letterSpacing:
-                          category.title.length > 20 ? '-0.06rem' : '',
-                      }}
-                    >
-                      {category.title}
-                    </span>
-                  </div>
-                </div>
-              );
-            })}
-          </div> */}
           <div className="grid grid-cols-2 gap-3 pb-10">
             {TempCategories.map((category, index) => {
               const bgColorClass = categoryBgColors[category.title] ?? '';

--- a/src/page/mypage/ui/list/MobileCheckList.tsx
+++ b/src/page/mypage/ui/list/MobileCheckList.tsx
@@ -35,7 +35,7 @@ export const MobileCheckList = ({
       <Icon className="h-full w-full" />
 
       <div
-        className={`absolute left-[22%] top-[25%] z-10 w-[30vw] max-w-[120px] p-2 text-center text-title-section font-semibold text-black ${bgColorClass}`}
+        className={`absolute left-[22%] top-[25%] z-10 w-[30vw] max-w-[120px] p-1 text-center text-[3vh] font-semibold text-black ${bgColorClass}`}
       >
         {category}
       </div>

--- a/src/page/mypage/ui/list/ScrapList.tsx
+++ b/src/page/mypage/ui/list/ScrapList.tsx
@@ -56,6 +56,7 @@ export const ScrapsList: React.FC<ScrapsListProps> = ({ favoriteList }) => {
           </div>
         );
       })}
+      {favoriteList.length === 0 && <div>스크랩한 문제가 없습니다</div>}
     </div>
   );
 };

--- a/src/page/mypage/ui/scrapListPage.tsx
+++ b/src/page/mypage/ui/scrapListPage.tsx
@@ -20,32 +20,34 @@ export const ScrapsListPage = () => {
   );
 
   return (
-    <div className="flex flex-col gap-[20px] p-8p">
-      <div className="text-title-page text-black dark:text-white">
-        Scrap folders
-      </div>
-      <div className="flex gap-4 text-black dark:text-white">
-        {TapButton.map((button) => (
-          <button
-            key={button.id}
-            onClick={() => setSelectedCategory(button.title)}
-            className={`text-button-1 transition-colors ${
-              selectedCategory === button.title
-                ? `${button.textColor}` // 선택된 색
-                : 'text-black'
-            }`}
-          >
-            {button.title}
-          </button>
-        ))}
-      </div>
-      <div className="h-[80vh] overflow-auto pb-[80px]">
-        <ScrapsList
-          favoriteList={(filteredList || []).map((item) => ({
-            ...item,
-            createdDt: String(item.createdDt),
-          }))}
-        />
+    <div className="w-screen p-4">
+      <div className="flex flex-col gap-[20px]">
+        <div className="text-title-page text-black dark:text-white">
+          Scrap folders
+        </div>
+        <div className="flex gap-4 text-black dark:text-white">
+          {TapButton.map((button) => (
+            <button
+              key={button.id}
+              onClick={() => setSelectedCategory(button.title)}
+              className={`text-button-1 transition-colors ${
+                selectedCategory === button.title
+                  ? `${button.textColor}` // 선택된 색
+                  : 'text-black dark:text-white'
+              }`}
+            >
+              {button.title}
+            </button>
+          ))}
+        </div>
+        <div className="h-[80vh] overflow-auto pb-[80px]">
+          <ScrapsList
+            favoriteList={(filteredList || []).map((item) => ({
+              ...item,
+              createdDt: String(item.createdDt),
+            }))}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/page/rank/ui/index.tsx
+++ b/src/page/rank/ui/index.tsx
@@ -4,6 +4,7 @@ import { SvgIcon } from '@mui/material';
 import Lv2Image from '@public/assets/icons/character/Lv2.svg';
 import Lv3Image from '@public/assets/icons/character/Lv3.svg';
 import Lv4Image from '@public/assets/icons/character/Lv4.svg';
+import { MyRankBox } from './myRank';
 
 import useRankPage from '../model/rankPageHook';
 import { TopRankUser } from './topRankUser';
@@ -14,37 +15,41 @@ const RankPage = () => {
   // 캐릭터 이미지는 임의로 넣음
   return (
     <div
-      className="flex h-full w-full flex-col overflow-scroll p-16p pb-[5rem] font-pixel font-bold text-white"
+      className="flex h-full w-full flex-col gap-[7%] overflow-scroll p-16p pb-[5rem] font-pixel font-bold text-white"
       style={{
         scrollbarWidth: 'none',
         msOverflowStyle: 'none',
       }}
     >
-      <span className="text-[32px] text-black dark:text-white">Ranking</span>
-      <div className="flex h-[clamp(8rem,30%,12rem)] w-full min-w-[15rem] items-end justify-center gap-[0.1rem] px-[5%]">
-        <TopRankUser
-          user={displayedUsers[1]}
-          levelIcon={Lv2Image}
-          heightClass="h-[86%]"
-          delayClass="delay-500"
-          rank="2"
-        />
-        <TopRankUser
-          user={displayedUsers[0]}
-          levelIcon={Lv4Image}
-          heightClass="h-full"
-          rank="1"
-        />
-        <TopRankUser
-          user={displayedUsers[2]}
-          levelIcon={Lv3Image}
-          heightClass="h-[80%]"
-          delayClass="delay-1000"
-          rank="3"
-        />
+      <div>
+        <span className="text-[32px] text-black dark:text-white">Ranking</span>
+        <div className="flex h-[clamp(8rem,30%,12rem)] w-full min-w-[15rem] items-end justify-center gap-[0.1rem] px-[5%]">
+          <TopRankUser
+            user={displayedUsers[1]}
+            levelIcon={Lv2Image}
+            heightClass="h-[86%]"
+            delayClass="delay-500"
+            rank="2"
+          />
+          <TopRankUser
+            user={displayedUsers[0]}
+            levelIcon={Lv4Image}
+            heightClass="h-full"
+            rank="1"
+          />
+          <TopRankUser
+            user={displayedUsers[2]}
+            levelIcon={Lv3Image}
+            heightClass="h-[80%]"
+            delayClass="delay-1000"
+            rank="3"
+          />
+        </div>
       </div>
-      <>
-        <div className="mt-[80px] flex flex-col gap-16p">
+
+      <div className="flex flex-col gap-8">
+        <MyRankBox />
+        <div className="flex flex-col gap-16p">
           {displayedUsers.map((user, index) =>
             index > 2 ? (
               <div key={user.rankNo} className="flex items-center gap-1">
@@ -71,7 +76,7 @@ const RankPage = () => {
             ) : null
           )}
         </div>
-      </>
+      </div>
     </div>
   );
 };

--- a/src/page/rank/ui/myRank.tsx
+++ b/src/page/rank/ui/myRank.tsx
@@ -1,0 +1,67 @@
+import Image from 'next/image';
+import { userStore } from '@/shared/state/userStore/model';
+import Lv2Image from '@public/assets/icons/character/Lv2.svg';
+import Lv3Image from '@public/assets/icons/character/Lv3.svg';
+import Lv4Image from '@public/assets/icons/character/Lv4.svg';
+import { SvgIcon } from '@mui/material';
+import useRankPage from '../model/rankPageHook';
+
+interface UserDataItem {
+  title: string;
+  value: string | number;
+}
+
+// 랭크 번호를 영어 서수(ordinal)로 변환
+function getOrdinalSuffix(rank: number | string): string {
+  const num = typeof rank === 'string' ? parseInt(rank, 10) : rank;
+  if (isNaN(num)) return '-';
+
+  const j = num % 10;
+  const k = num % 100;
+
+  if (j === 1 && k !== 11) return `${num}st`;
+  if (j === 2 && k !== 12) return `${num}nd`;
+  if (j === 3 && k !== 13) return `${num}rd`;
+  return `${num}th`;
+}
+
+export const MyRankBox = () => {
+  const { user } = userStore();
+  const { displayedUsers } = useRankPage();
+
+  const score = user?.userScore ?? 0;
+  const level = Math.floor(score / 1000);
+
+  const myRankData = displayedUsers.find((u) => u.userId === user?.userId);
+  const rankNo = myRankData?.rankNo ?? '-';
+
+  const userData: UserDataItem[] = [
+    { title: 'Rank', value: getOrdinalSuffix(rankNo) },
+    { title: 'Level', value: level },
+    { title: 'Score', value: score },
+  ];
+
+  return (
+    <div className="flex h-[100px] w-full items-center justify-between rounded-lg bg-point-purple/60 px-[6%] font-pixel text-[2.7vh] text-white">
+      {/* 왼쪽 아바타 + 이름 */}
+      <div className="flex flex-col items-center justify-center">
+        <SvgIcon
+          component={Lv4Image}
+          inheritViewBox
+          sx={{ width: '50px', height: '50px' }}
+        />
+        <span className="text-[1.8vh]">Me</span>
+      </div>
+
+      {/* 오른쪽 데이터 영역 */}
+      <div className="flex flex-1 justify-around">
+        {userData.map((item) => (
+          <div key={item.title} className="flex flex-col items-center">
+            <span>{item.title}</span>
+            <span>{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/page/rank/ui/myRank.tsx
+++ b/src/page/rank/ui/myRank.tsx
@@ -1,7 +1,4 @@
-import Image from 'next/image';
 import { userStore } from '@/shared/state/userStore/model';
-import Lv2Image from '@public/assets/icons/character/Lv2.svg';
-import Lv3Image from '@public/assets/icons/character/Lv3.svg';
 import Lv4Image from '@public/assets/icons/character/Lv4.svg';
 import { SvgIcon } from '@mui/material';
 import useRankPage from '../model/rankPageHook';
@@ -11,7 +8,6 @@ interface UserDataItem {
   value: string | number;
 }
 
-// 랭크 번호를 영어 서수(ordinal)로 변환
 function getOrdinalSuffix(rank: number | string): string {
   const num = typeof rank === 'string' ? parseInt(rank, 10) : rank;
   if (isNaN(num)) return '-';

--- a/src/shared/button/DarkModeButton.tsx
+++ b/src/shared/button/DarkModeButton.tsx
@@ -1,11 +1,16 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import SunIcon from '@public/assets/icons/button/toggle/sun.png';
 import { FaMoon } from 'react-icons/fa';
 
 export const DarkModeButton = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    // 초기 상태 동기화
+    setIsDarkMode(document.documentElement.classList.contains('dark'));
+  }, []);
 
   const toggleDarkMode = () => {
     const newMode = !isDarkMode;
@@ -14,7 +19,6 @@ export const DarkModeButton = () => {
   };
 
   return (
-    // pointer-events-auto를 넣어서 클릭 가능하게 보장
     <div className="pointer-events-auto relative z-[1000000]">
       <button
         onClick={toggleDarkMode}

--- a/src/shared/input/inputForm.tsx
+++ b/src/shared/input/inputForm.tsx
@@ -11,7 +11,7 @@ const InputForm = ({
   status: InputStatus;
 } & React.InputHTMLAttributes<HTMLInputElement>) => {
   const baseClasses =
-    'w-full px-[16px] py-[12px] rounded-12p border outline-none transition-all bg-background';
+    'w-full px-[16px] py-[12px] rounded-12p border outline-none transition-all bg-background placeholder:text-black dark:placeholder:text-white';
 
   const statusClasses = {
     empty:
@@ -27,7 +27,7 @@ const InputForm = ({
   return (
     <input
       ref={ref}
-      className={`${baseClasses} ${statusClasses[status]} ${className} shrink-0 caret-black dark:caret-white`}
+      className={`${baseClasses} ${statusClasses[status]} ${className} shrink-0 text-black dark:text-white`}
       disabled={isDisabled}
       {...props}
     />


### PR DESCRIPTION
🤖 **자동 생성된 커밋 요약 (GPT-4o)**

### 🧾 스크랩 리스트 페이지의 CSS 레이아웃 및 스타일 개선 [fadd9c8]

- 페이지의 전체 레이아웃을 화면 너비에 맞게 조정하여 `w-screen` 클래스를 추가했습니다.
- 버튼의 텍스트 색상을 다크 모드에서도 적용되도록 `dark:text-white` 클래스를 추가했습니다.


### 🧾 북마크 기능 개선 및 토스트 메시지 추가 [420573c]

- 문제 북마크 기능이 추가되어 문제 ID를 기반으로 북마크를 토글할 수 있도록 개선되었습니다.
- 북마크 추가 성공 또는 실패 시 사용자에게 알림을 제공하는 토스트 메시지가 추가되었습니다.


### 🧾 다크 모드 지원을 위한 스타일 업데이트 [eaea75a]

- 로그인 페이지와 입력 폼에 다크 모드 시 텍스트 색상을 흰색으로 변경하여 가독성을 개선했습니다.
- 프로필 이미지의 z-index를 조정하여 레이아웃 문제를 해결했습니다.
- 랭크 페이지에서 사용되지 않는 이미지 임포트를 제거하여 코드 정리를 수행했습니다.


### 🧾 마이페이지 UI 및 스타일 업데이트 [0157ffa]

- `GassCalnerder.tsx`에서 날짜 셀의 배경색과 텍스트 색상이 변경되었습니다. 셀의 간격이 넓어졌고, 카운트가 0인 경우 텍스트가 표시되지 않도록 수정되었습니다.
- `Item.tsx`에서 주석 처리된 불필요한 코드가 제거되었습니다.
- `categoryProblemHistory.tsx`에서 로그 출력이 추가되었고, 페이지 하단의 여백이 조정되었습니다.
- `CheckList.tsx`와 `MobileCheckList.tsx`에서 주석 처리된 코드가 제거되었으며, 모바일 체크리스트의 텍스트 크기가 조정되었습니다.
- `ScrapList.tsx`에 스크랩한 문제가 없을 경우 표시할 메시지가 추가되었습니다.


### 🧾 랭크 페이지 UI 개선 및 사용자 랭크 박스 추가 [0917b4e]

- 프로필 모달 UI에서 텍스트 색상을 검정으로 변경하고 버튼 스타일을 업데이트했습니다.
- 랭크 페이지에 사용자 자신의 랭크 정보를 표시하는 `MyRankBox` 컴포넌트를 추가했습니다.
- `MyRankBox` 컴포넌트는 사용자 아바타, 이름, 랭크, 레벨, 점수를 표시합니다.


### 🧾 다크 모드 초기 상태 동기화 및 적용 [8629ed4]

- HTML 태그에 `dark` 클래스를 추가하여 다크 모드가 기본적으로 적용되도록 변경했습니다.
- `DarkModeButton` 컴포넌트에서 `useEffect`를 사용하여 초기 렌더링 시 다크 모드 상태를 동기화하도록 수정했습니다.